### PR TITLE
Move user friendly formatting to UserFriendlyFormatter

### DIFF
--- a/lib/text_sanitizer.ex
+++ b/lib/text_sanitizer.ex
@@ -1,0 +1,52 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2019 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule PrettyLog.TextSanitizer do
+  alias Logger.Formatter
+
+  def sanitize_keyword(keywords) do
+    Enum.map(keywords, fn {k, v} ->
+      {k, sanitize(v)}
+    end)
+  end
+
+  def sanitize(value) when is_atom(value) do
+    Atom.to_string(value)
+  end
+
+  def sanitize(value) when is_binary(value) do
+    Formatter.prune(value)
+  end
+
+  def sanitize(value) when is_list(value) do
+    value
+    |> Formatter.prune()
+    |> :erlang.iolist_to_binary()
+  rescue
+    _ ->
+      value
+      |> :erlang.term_to_binary()
+      |> Base.encode64()
+  end
+
+  def sanitize(value) do
+    value
+    |> :erlang.term_to_binary()
+    |> Base.encode64()
+  end
+end

--- a/test/log_fmt_formatter_test.exs
+++ b/test/log_fmt_formatter_test.exs
@@ -1,9 +1,9 @@
-defmodule PrettyLogLogFmtFormatterTest do
+defmodule PrettyLog.LogFmtFormatterTest do
   use ExUnit.Case
   alias PrettyLog.LogFmtFormatter
   doctest PrettyLog.LogFmtFormatter
 
-  test "produces a warning log entry" do
+  test "formats a warning log entry" do
     assert :erlang.iolist_to_binary(
              LogFmtFormatter.format(
                :warn,

--- a/test/user_friendly_formatter_test.exs
+++ b/test/user_friendly_formatter_test.exs
@@ -1,0 +1,16 @@
+defmodule PrettyLog.UserFriendlyFormatterTest do
+  use ExUnit.Case
+  alias PrettyLog.UserFriendlyFormatter
+  doctest PrettyLog.UserFriendlyFormatter
+
+  test "formats a warning log entry" do
+    assert :erlang.iolist_to_binary(
+             UserFriendlyFormatter.format(
+               :warn,
+               "This is a test message",
+               {{2019, 10, 8}, {11, 58, 39, 5}},
+               []
+             )
+           ) == "11:58:39.5\t|WARN | This is a test message                          \t| \n"
+  end
+end


### PR DESCRIPTION
User friendly log formatting code should stay in its own module instead of
relying on user_friendly config option.