### PR TITLE
mix.exs: use logfmt fork

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule PrettyLog.MixProject do
 
   defp deps do
     [
-      {:logfmt, "~> 3.3"}
+      {:logfmt, github: "bettio/logfmt-elixir", branch: "escape-quotes-and-unprintable"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{
-  "logfmt": {:hex, :logfmt, "3.3.0", "f863e19b9cac952f177f878074ec9304bb132eb9034306e75216dee88ca744d9", [:mix], [], "hexpm"},
+  "logfmt": {:git, "https://github.com/bettio/logfmt-elixir.git", "5a33be9eefa07a0d408caa3e9fbb07708bd597ce", [branch: "escape-quotes-and-unprintable"]},
 }


### PR DESCRIPTION
logfmt has no quotes escaping support, hence use a fork of it.
Use this fork until https://github.com/jclem/logfmt-elixir/issues/13 gets fixed.