### PR TITLE
Rename LogFmt to Logfmt

### DIFF
--- a/lib/logfmt_formatter.ex
+++ b/lib/logfmt_formatter.ex
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-defmodule PrettyLog.LogFmtFormatter do
+defmodule PrettyLog.LogfmtFormatter do
   alias PrettyLog.TextSanitizer
 
   epoch = {{1970, 1, 1}, {0, 0, 0}}

--- a/test/logfmt_formatter_test.exs
+++ b/test/logfmt_formatter_test.exs
@@ -1,11 +1,11 @@
-defmodule PrettyLog.LogFmtFormatterTest do
+defmodule PrettyLog.LogfmtFormatterTest do
   use ExUnit.Case
-  alias PrettyLog.LogFmtFormatter
-  doctest PrettyLog.LogFmtFormatter
+  alias PrettyLog.LogfmtFormatter
+  doctest PrettyLog.LogfmtFormatter
 
   test "formats a warning log entry" do
     assert :erlang.iolist_to_binary(
-             LogFmtFormatter.format(
+             LogfmtFormatter.format(
                :warn,
                "This is a test message",
                {{2019, 10, 8}, {11, 58, 39, 5}},


### PR DESCRIPTION
Logfmt is more widely used, so change it also here.