### PR TITLE
TextSanitizer: handle integers, floats, pids, ports and refs

### DIFF
--- a/lib/text_sanitizer.ex
+++ b/lib/text_sanitizer.ex
@@ -33,6 +33,18 @@ defmodule PrettyLog.TextSanitizer do
     Formatter.prune(value)
   end
 
+  def sanitize(value) when is_integer(value) do
+    Integer.to_string(value)
+  end
+
+  def sanitize(value) when is_float(value) do
+    Float.to_string(value)
+  end
+
+  def sanitize(value) when is_pid(value) or is_port(value) or is_reference(value) do
+    inspect(value)
+  end
+
   def sanitize(value) when is_list(value) do
     value
     |> Formatter.prune()

--- a/test/logfmt_formatter_test.exs
+++ b/test/logfmt_formatter_test.exs
@@ -14,4 +14,16 @@ defmodule PrettyLog.LogfmtFormatterTest do
            ) ==
              "level=warn ts=2019-10-08T11:58:39.005+02:00 msg=\"This is a test message\"\n"
   end
+
+  test "formats an error log entry with an integer metadata" do
+    assert :erlang.iolist_to_binary(
+             LogfmtFormatter.format(
+               :warn,
+               "This is a test message",
+               {{2019, 10, 8}, {11, 58, 39, 5}},
+               line: 100
+             )
+           ) ==
+             "level=warn ts=2019-10-08T11:58:39.005+02:00 msg=\"This is a test message\" line=100\n"
+  end
 end


### PR DESCRIPTION
Do not base64 encode human readable values.