### PR TITLE
TextSanitizer: prefix base64 encoded terms

### DIFF
--- a/lib/text_sanitizer.ex
+++ b/lib/text_sanitizer.ex
@@ -51,14 +51,19 @@ defmodule PrettyLog.TextSanitizer do
     |> :erlang.iolist_to_binary()
   rescue
     _ ->
-      value
-      |> :erlang.term_to_binary()
-      |> Base.encode64()
+      base64_encode_term(value)
   end
 
   def sanitize(value) do
-    value
-    |> :erlang.term_to_binary()
-    |> Base.encode64()
+    base64_encode_term(value)
+  end
+
+  defp base64_encode_term(value) do
+    b64_encoded =
+      value
+      |> :erlang.term_to_binary()
+      |> Base.encode64()
+
+    "base64-encoded-ext-term:" <> b64_encoded
   end
 end

--- a/test/logfmt_formatter_test.exs
+++ b/test/logfmt_formatter_test.exs
@@ -26,4 +26,17 @@ defmodule PrettyLog.LogfmtFormatterTest do
            ) ==
              "level=warn ts=2019-10-08T11:58:39.005+02:00 msg=\"This is a test message\" line=100\n"
   end
+
+  test "formats an info log entry with a tuple metadata" do
+    assert :erlang.iolist_to_binary(
+             LogfmtFormatter.format(
+               :warn,
+               "This is a test message",
+               {{2019, 10, 8}, {11, 58, 39, 5}},
+               tuple: {:foo, 42, :bar}
+             )
+           ) ==
+             "level=warn ts=2019-10-08T11:58:39.005+02:00 msg=\"This is a test message\" " <>
+               "tuple=\"base64-encoded-ext-term:g2gDZAADZm9vYSpkAANiYXI=\"\n"
+  end
 end


### PR DESCRIPTION
Prefix base64 encoded terms with "base64-encoded-ext-term:", so they don't get confused with other base64 strings.