### PR TITLE
Feat customise labels names, fix tests, drop message if empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Just change the `:format` config entry in your config/{prod,dev,test}.exs files:
 
 metadata is arbitrary and optional.
 
+You may change the default key names via the following config options, values must be atoms:
+
+```elixir
+config :pretty_log,
+  :timestamp_key_name, :when, # defaults to :ts
+  :level_key_name, :severity, # defaults to :level
+  :message_key_name, :humans, # defaults to :msg
+```
+
 ## Available Formatters
 
 Following formatters are included:

--- a/lib/logfmt_formatter.ex
+++ b/lib/logfmt_formatter.ex
@@ -27,6 +27,10 @@ defmodule PrettyLog.LogfmtFormatter do
 
     pre_message_metadata = Application.get_env(:logfmt, :prepend_metadata, [])
 
+    timestamp_key_name = Application.get_env(:pretty_log, :timestamp_key_name, :ts)
+    message_key_name = Application.get_env(:pretty_log, :message_key_name, :msg)
+    level_key_name = Application.get_env(:pretty_log, :level_key_name, :level)
+
     {pre_meta, metadata} = Keyword.split(metadata, pre_message_metadata)
 
     timestamp =
@@ -41,7 +45,13 @@ defmodule PrettyLog.LogfmtFormatter do
 
     kv =
       TextSanitizer.sanitize_keyword(
-        [{:level, level}, {:ts, timestamp_string} | pre_meta] ++ [{:msg, message} | metadata]
+        [
+          {level_key_name, level},
+          {timestamp_key_name, timestamp_string} | pre_meta
+        ] ++
+          [
+            {message_key_name, message} | metadata
+          ]
       )
 
     [Logfmt.encode(kv), "\n"]

--- a/test/logfmt_formatter_test.exs
+++ b/test/logfmt_formatter_test.exs
@@ -10,6 +10,7 @@ defmodule PrettyLog.LogfmtFormatterTest do
 
   def local_tz_offset(time) do
     {date, {h, m, s, millis}} = time
+
     timestamp =
       {date, {h, m, s}}
       |> :erlang.localtime_to_universaltime()
@@ -73,5 +74,71 @@ defmodule PrettyLog.LogfmtFormatterTest do
            ) ==
              "level=debug ts=2019-10-08T11:58:39.005+#{local_tz_offset(@time)} msg=\"This is a test message\" " <>
                "kwlist=\"base64-encoded-ext-term:g2wAAAACaAJkAAFhYQFoAmQAAWJhAmo=\"\n"
+  end
+
+  describe "level key name configuration" do
+    setup do
+      Application.put_env(:pretty_log, :level_key_name, :severity)
+
+      on_exit(fn ->
+        Application.delete_env(:pretty_log, :level_key_name)
+      end)
+    end
+
+    test "sets level key" do
+      assert :erlang.iolist_to_binary(
+               LogfmtFormatter.format(
+                 :warn,
+                 "This is a test message",
+                 @time,
+                 []
+               )
+             ) ==
+               "severity=warn ts=2019-10-08T11:58:39.005+#{local_tz_offset(@time)} msg=\"This is a test message\"\n"
+    end
+  end
+
+  describe "timestamp name configuration" do
+    setup do
+      Application.put_env(:pretty_log, :timestamp_key_name, :event_at)
+
+      on_exit(fn ->
+        Application.delete_env(:pretty_log, :timestamp_key_name)
+      end)
+    end
+
+    test "sets timestamp key" do
+      assert :erlang.iolist_to_binary(
+               LogfmtFormatter.format(
+                 :warn,
+                 "This is a test message",
+                 @time,
+                 []
+               )
+             ) ==
+               "level=warn event_at=2019-10-08T11:58:39.005+#{local_tz_offset(@time)} msg=\"This is a test message\"\n"
+    end
+  end
+
+  describe "message name configuration" do
+    setup do
+      Application.put_env(:pretty_log, :message_key_name, :note_to_human)
+
+      on_exit(fn ->
+        Application.delete_env(:pretty_log, :message_key_name)
+      end)
+    end
+
+    test "sets message key" do
+      assert :erlang.iolist_to_binary(
+               LogfmtFormatter.format(
+                 :warn,
+                 "This is a test message",
+                 @time,
+                 []
+               )
+             ) ==
+               "level=warn ts=2019-10-08T11:58:39.005+#{local_tz_offset(@time)} note_to_human=\"This is a test message\"\n"
+    end
   end
 end


### PR DESCRIPTION
This patch ended up doing 3 things (sorry):

1. Fix tests to run in any timezone.
2. Allow for configuration of default key names (`ts`, `level` and `msg`) via `put_env`/`config`, under the `:pretty_log` namespace.
3. Do not insert `msg` key if message is blank.

3 might be controversial, maybe more expected behavior is to include it as `msg=""`. Before this PR it is included as `msg=` which probably has the potential to trip up some parsers.