### PR TITLE
Bump version number to 0.9.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrettyLog.MixProject do
   def project do
     [
       app: :pretty_log,
-      version: "0.1.0",
+      version: "0.9.0",
       elixir: "~> 1.8",
       deps: deps(),
       description: description(),


### PR DESCRIPTION
pretty_log is reaching a stable state, so jump straight to 0.9.0.